### PR TITLE
Add simple time-keeping and cron job infrastructure

### DIFF
--- a/pleo-antaeus-app/src/main/kotlin/io/pleo/antaeus/app/AntaeusApp.kt
+++ b/pleo-antaeus-app/src/main/kotlin/io/pleo/antaeus/app/AntaeusApp.kt
@@ -5,6 +5,7 @@ package io.pleo.antaeus.app
 import io.pleo.antaeus.core.services.BillingService
 import io.pleo.antaeus.core.services.CustomerService
 import io.pleo.antaeus.core.services.InvoiceService
+import io.pleo.antaeus.core.time.Clock
 import io.pleo.antaeus.data.AntaeusDal
 import io.pleo.antaeus.data.CustomerTable
 import io.pleo.antaeus.data.InvoiceTable
@@ -44,11 +45,14 @@ fun main() {
     val invoiceService = InvoiceService(dal = dal)
     val customerService = CustomerService(dal = dal)
 
+    val clock = Clock()
+
     // TODO(shane) consider using di.
     BillingService(
             paymentProvider = paymentProvider,
             invoiceService = invoiceService,
-            dal = dal
+            dal = dal,
+            clock = clock
     )
 
     AntaeusRest(

--- a/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/time/Clock.kt
+++ b/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/time/Clock.kt
@@ -1,0 +1,27 @@
+package io.pleo.antaeus.core.time
+
+import java.time.Duration
+import java.time.ZonedDateTime
+import java.time.Clock as JavaClock
+
+class Clock {
+    private var clock: JavaClock = JavaClock.systemDefaultZone()
+    private val watchers: MutableList<ClockWatcher> = mutableListOf()
+
+    fun watch(watcher: ClockWatcher) {
+        watchers.add(watcher)
+    }
+
+    @Synchronized
+    fun currentTime(): ZonedDateTime {
+        return ZonedDateTime.now(clock)
+    }
+
+    @Synchronized
+    fun advance(offset: Duration) {
+        clock = JavaClock.offset(clock, offset)
+        for (watcher in watchers) {
+            watcher.timeChanged()
+        }
+    }
+}

--- a/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/time/ClockWatcher.kt
+++ b/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/time/ClockWatcher.kt
@@ -1,0 +1,5 @@
+package io.pleo.antaeus.core.time
+
+interface ClockWatcher {
+    fun timeChanged()
+}

--- a/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/time/CronJob.kt
+++ b/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/time/CronJob.kt
@@ -1,0 +1,57 @@
+package io.pleo.antaeus.core.time
+
+import com.github.shyiko.skedule.Schedule
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.thread
+
+class CronJob(
+        private val schedule: Schedule,
+        private val clock: Clock,
+        private val task: () -> Unit
+) : ClockWatcher {
+    private var next: ZonedDateTime
+    private var waiter: Thread
+    private val lock: Lock = ReentrantLock()
+
+    init {
+        clock.watch(this)
+        next = schedule.next(clock.currentTime())
+
+        waiter = thread { startWaiter() }
+    }
+
+    override fun timeChanged() {
+        waiter.interrupt()
+        checkTime()
+    }
+
+    private fun startWaiter() {
+        while (true) {
+            try {
+                // This will not cause overflow, as long as no schedule has a period
+                // of over 292 million years.
+                Thread.sleep(ChronoUnit.MILLIS.between(next, clock.currentTime()))
+            } catch (e: InterruptedException) {
+                // We have been interrupted, re-calculate our sleep duration.
+                continue
+            }
+
+            checkTime()
+        }
+    }
+
+    private fun checkTime() {
+        lock.lock()
+        if (next < clock.currentTime()) {
+            next = schedule.next(clock.currentTime())
+            lock.unlock()
+
+            task()
+        } else {
+            lock.unlock()
+        }
+    }
+}


### PR DESCRIPTION
Add a clock implementation, which can be manually advanced (useful for changing the time after configuration, or during tests), as well as a cron job implementation, which will be used to run the invoice charger.